### PR TITLE
Update docs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -71,13 +71,8 @@ jobs:
       - uses: julia-actions/setup-julia@v2
         with:
           version: '1'
-      - run: |
-          julia --project=docs -e '
-            using Pkg
-            Pkg.develop(PackageSpec(path=pwd()))
-            Pkg.instantiate()'
-      - run: julia --project=docs docs/make.jl
-        env:
+      - uses: julia-actions/cache@v2
+      - uses: julia-actions/julia-docdeploy@v1
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
           GKSwstype: "100" # fix GKS socket error for plots made in @example blocks

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -73,6 +73,7 @@ jobs:
           version: '1'
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-docdeploy@v1
+        env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
           GKSwstype: "100" # fix GKS socket error for plots made in @example blocks

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -55,8 +55,14 @@ jobs:
         with:
           version: '1'
       - uses: julia-actions/julia-buildpkg@v1
-      - run: julia --color=yes -e 'using Pkg; Pkg.add("Aqua")'
-      - run: julia --color=yes --project=@. -e 'using Aqua, BoxLeastSquares; Aqua.test_all(BoxLeastSquares; ambiguities=false)'
+      - shell: julia --color=yes {0}
+        run: |
+          using Pkg
+          Pkg.add("Aqua")
+      - shell: julia --color=yes --project=@. {0}
+        run: |
+          using Aqua, BoxLeastSquares
+          Aqua.test_all(BoxLeastSquares; ambiguities=false)
   docs:
     name: Documentation
     runs-on: ubuntu-latest

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -7,3 +7,12 @@ Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 UnitfulRecipes = "42071c24-d89e-48dd-8a24-8a12d9b8861f"
+
+[compat]
+CSV = "0.10"
+DataFrames = "1"
+Documenter = "1"
+StableRNGs = "1"
+Unitful = "1.22"
+UnitfulRecipes = "1.6"
+

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -16,3 +16,5 @@ StableRNGs = "1"
 Unitful = "1.22"
 UnitfulRecipes = "1.6"
 
+[sources.BoxLeastSquares]
+path = ".."

--- a/docs/pages.jl
+++ b/docs/pages.jl
@@ -1,4 +1,4 @@
-pages=[
+pages = [
         "Home" => "index.md",
         "API/Reference" => "api.md"
     ]

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -198,8 +198,8 @@ Environment:
 ```@example
 using CSV, DataFrames, Plots # hide
 using BoxLeastSquares # hide
-benchdir = joinpath(dirname(pathof(BoxLeastSquares)), "..", "bench") # hide
-results = DataFrame(CSV.File(joinpath(benchdir, "benchmark_results.csv"))) # hide
+benchdir = joinpath(pkgdir(BoxLeastSquares), "bench") # hide
+results = CSV.read(joinpath(benchdir, "benchmark_results.csv"), DataFrame) # hide
 groups = groupby(results, :N_per) # hide
 
 plot(xlabel="# data points", ylabel="time (s)") # hide

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -15,12 +15,12 @@ CurrentModule = BoxLeastSquares
 
 To install use [Pkg](https://julialang.github.io/Pkg.jl/v1/managing-packages/). From the REPL, press `]` to enter Pkg-mode
 
-```julia
+```julia-repl
 pkg> add BoxLeastSquares
 ```
 If you want to use the most up-to-date version of the code, check it out from `main`
 
-```julia
+```julia-repl
 pkg> add BoxLeastSquares#main
 ```
 
@@ -34,7 +34,7 @@ julia> using BoxLeastSquares
 
 you can optionally alias the package name, too
 
-```julia
+```julia-repl
 julia> import BoxLeastSquares as BLS
 ```
 
@@ -181,7 +181,7 @@ This code has been benchmarked against the C implementation in [`astropy.timeser
 
 This first benchmark is simply the time it takes to evaluate the BLS periodogram. Periods are pre-computed using [`autoperiod`](@ref). We simulate different sizes of data sets (x-axis) as well as different sizes of period grids (shape). This benchmark does not use units. The code can be found in `bench/benchmark.jl`. Here is the information for my system-
 
-```julia
+```plain
 Julia Version 1.6.0
 Commit f9720dc2eb* (2021-03-24 12:55 UTC)
 Platform Info:


### PR DESCRIPTION
Currently, the documentation deploy fails because of a `check_args` failure from LoopVectorization.jl. This PR does not address that. It also does not do anything to affect any other test failures/successes.